### PR TITLE
Allow Rails 4 or Rails 5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     extra_extra (1.0.4)
-      rails (~> 5)
+      rails (~> 5, >= 4)
       redcarpet (>= 3.3.2)
 
 GEM

--- a/extra_extra.gemspec
+++ b/extra_extra.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_runtime_dependency "rails", "~> 5"
+  s.add_runtime_dependency "rails", ">= 4", "~> 5"
   s.add_runtime_dependency "redcarpet", ">= 3.3.2"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency 'rspec-rails'


### PR DESCRIPTION
# Problem

The previous PR restricted the gem to only Rails 5. This was too restrictive and would have required an unnecessary major version bump.

# Solution

Reintroduce anything over Rails 4, and allow for any version of Rails 5 as well.