### PR TITLE
Allow Rails 6 builds

### DIFF
--- a/extra_extra.gemspec
+++ b/extra_extra.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_runtime_dependency "rails", ">= 4", "~> 5"
+  s.add_runtime_dependency "rails", ">= 4"
   s.add_runtime_dependency "redcarpet", ">= 3.3.2"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency 'rspec-rails'

--- a/spec/dummy/app/assets/config/manifest.js
+++ b/spec/dummy/app/assets/config/manifest.js
@@ -1,0 +1,3 @@
+//= link_tree ../images
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css


### PR DESCRIPTION
Rails is restricted to version 5 only. Lift restriction to allow Rails 6 builds.