### PR TITLE
Install Sqlite3 in circle images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
         password: "$DOCKERHUB_PASSWORD"
     steps:
     - checkout
-    - run: apt-get install libsqlite3-dev
+    - run: sudo apt-get update && sudo apt-get install libsqlite3-dev
     - run: bundle config stitchfix01.jfrog.io $ARTIFACTORY_USER:$ARTIFACTORY_TOKEN
     - run: bundle install --full-index
     - run:
@@ -33,6 +33,7 @@ jobs:
         password: "$DOCKERHUB_PASSWORD"
     steps:
     - checkout
+    - run: sudo apt-get update && sudo apt-get install libsqlite3-dev
     - run: bundle config stitchfix01.jfrog.io $ARTIFACTORY_USER:$ARTIFACTORY_TOKEN
     - run: bundle install --full-index
     - run:
@@ -53,6 +54,7 @@ jobs:
     working_directory: "~/extra_extra"
     steps:
     - checkout
+    - run: sudo apt-get update && sudo apt-get install libsqlite3-dev
     - run:
         name: Check for Gemfile.lock presence
         command: ' if (test -f Gemfile.lock) then echo "Dont commit Gemfile.lock (see
@@ -83,6 +85,7 @@ jobs:
     working_directory: "~/extra_extra"
     steps:
     - checkout
+    - run: sudo apt-get update && sudo apt-get install libsqlite3-dev
     - run:
         name: Check for Gemfile.lock presence
         command: ' if (test -f Gemfile.lock) then echo "Dont commit Gemfile.lock (see
@@ -113,6 +116,7 @@ jobs:
     working_directory: "~/extra_extra"
     steps:
     - checkout
+    - run: sudo apt-get update && sudo apt-get install libsqlite3-dev
     - run:
         name: Check for Gemfile.lock presence
         command: ' if (test -f Gemfile.lock) then echo "Dont commit Gemfile.lock (see
@@ -143,6 +147,7 @@ jobs:
     working_directory: "~/extra_extra"
     steps:
     - checkout
+    - run: sudo apt-get update && sudo apt-get install libsqlite3-dev
     - run:
         name: Check for Gemfile.lock presence
         command: ' if (test -f Gemfile.lock) then echo "Dont commit Gemfile.lock (see

--- a/build-matrix.json
+++ b/build-matrix.json
@@ -1,4 +1,7 @@
 {
   "build_matrix": {
+    "packages": [
+      "libsqlite3-dev"
+    ]
   }
 }


### PR DESCRIPTION
## Problem

New CircleCI images do not include package required for `sqlite`.

## Solution

Add package to `build-matrix.json` packages and - one time only! - manually update the build matrix to install `libsqlite3-dev`.
